### PR TITLE
blog: SPLC indictment and the institutional trust problem

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -59,5 +59,5 @@ menu = [
 # Author information
 [extra.authors]
 JM = { name = "Joshua Moon", image = "image/authors/JM.webp", social = "https://x.com/XJosh", title = "Founding Member, President, Treasurer", bio = "Antifragile systems architect. Dislikes card networks." }
-KC = { name = "Kevin Crawley", image = "image/authors/kc.png", social = "https://x.com/kvncrw", title = "Founding Member, Vice PPresident", bio = "Kevin is a software engineer and privacy advocate who has extensive experience in systems engineering and web application development. When he's not coercing LLMs into doing his bidding, he enjoys flying drones and playing with his dog." }
+KC = { name = "Kevin Crawley", image = "image/authors/kc.png", social = "https://x.com/kvncrw", title = "Founding Member, Vice President", bio = "Kevin is a software engineer and privacy advocate who has extensive experience in systems engineering and web application development. When he's not coercing LLMs into doing his bidding, he enjoys flying drones and playing with his dog." }
 MH = { name = "Matthew Hardin", image = "image/authors/dickbutt.png", title = "Founding Member, Secretary", bio = "Matthew is a privacy researcher and advocate with a background in computer science. He is passionate about open-source software and digital rights." }

--- a/content/blog/2026/05/_index.md
+++ b/content/blog/2026/05/_index.md
@@ -1,0 +1,5 @@
++++
+title = "May 2026"
+transparent = true
+template = "blog.html"
++++

--- a/content/blog/2026/05/splc-indictment-and-trust.md
+++ b/content/blog/2026/05/splc-indictment-and-trust.md
@@ -1,0 +1,55 @@
++++
+title = "A Nonprofit, Five Shell Accounts, and a Written Confession"
+date = 2026-05-02
+description = "The SPLC was indicted for bank fraud. The mechanics are boring. The implications for who controls financial infrastructure in this country are not."
+[extra]
+author = "KC"
++++
+
+How do you trust an institution after you watch it run a covert banking operation for thirty years?
+
+The Southern Poverty Law Center — the same organization that built a database used by Visa, Mastercard, PayPal, and half the payments stack to decide who gets to participate in the financial system — was indicted on April 21 for bank fraud. Patrick McKenzie's writeup at *Bits About Money*, ["The nonprofit indicted for bank fraud,"](https://www.bitsaboutmoney.com/archive/nonprofit-indicted-bank-fraud/) is the cleanest summary of the legal mechanics you'll find, and you should read it before you read me.
+
+The short version: senior SPLC employees, including the CFO and the head of the Intelligence Project, opened business accounts at U.S. banks under names like **Center Investigative Agency** ("CIA" — yes, really), **Fox Photography**, **North West Technologies**, and **Tech Writers Group**. None of those entities did business. None of them filed taxes as real companies. They existed to receive donor money and route it to informants embedded in extremist groups.
+
+In 2020, a bank noticed and started closing accounts. The SPLC's CEO then wrote a letter to the bank confirming the accounts "were opened for the benefit of Southern Poverty Law Center operations and operated under the Center's authority." McKenzie calls this "a succinct confession to bank fraud." That's not hyperbole — under [18 USC §1014](https://www.law.cornell.edu/uscode/text/18/1014), prosecutors don't need to prove intent or materiality. They need to prove that someone made false statements to a federally insured institution. The CEO put it in writing.
+
+## The part that should make you cold
+
+Here's where it stops being a tidy white-collar prosecution and starts being something else.
+
+For roughly five years (2017–2021), the SPLC ran a coordinated pressure campaign — through the *Change the Terms* coalition — to push banks, payment processors, and tech platforms to deplatform individuals and groups based on its own *Extremist Files* list. They held hundreds of meetings. They testified to Congress that "a key part of this strategy has been to target these organizations' funding." They successfully wired their political designations into the same screening systems built to interdict actual terrorist financing.
+
+Stack the facts:
+
+- An organization runs fictitious bank accounts for thirty years.
+- The same organization spends five years lobbying banks to choke off the financial lives of people it dislikes.
+- The same organization gets caught, confesses in writing, and we're now meant to argue about whether the prosecution is "political."
+
+To be clear, the SPLC has done real civil rights work, and most of the staff who walked through its doors over the decades were not running shell accounts. This is about an arm of the institution and the leaders who steered it — a soft-power game played quietly above the line workers' heads. Recognizing both things at once is the only honest way to read this.
+
+If you're a free speech absolutist, this is your nightmare. If you're a compliance officer at a bank that took an SPLC meeting in 2019 and then closed accounts based on what you heard, you should be losing sleep right now. If you're a donor who sent the SPLC money believing it was a civil rights organization rather than an arm running covert banking infrastructure, you are entitled to be furious.
+
+## How do we trust our institutions ever again?
+
+I want to take this seriously as a question, not a rhetorical flourish.
+
+The standard answer — *strong institutions, professional norms, oversight* — was the answer the SPLC itself invoked when it asked Visa to ban a competitor or asked Chase to drop a customer. Trust the experts. Trust the lists. Trust the process. The institutions said the right things in public and ran shell companies in private. The compliance regime they helped weaponize cannot now save them, and it shouldn't.
+
+Three uncomfortable conclusions:
+
+1. **Reputation is not a substitute for audit.** The SPLC was treated as authoritative by serious financial institutions for decades, in large part because of its reputation. Reputation didn't catch *Fox Photography*. A line-level banker did, in 2020, by reading account activity. The next time someone tells you an organization is too prestigious to question, remember that the prestige was a *requirement* for the deception — without it, the shell accounts get flagged on day one.
+
+2. **Concentrated soft power over financial rails is the actual problem.** It doesn't matter whether the entity holding the deplatforming pen is the SPLC, the ADL, a state AG's office, or a future administration's preferred NGO. Once that muscle exists — the ability to debank political opponents through "voluntary" pressure on payments infrastructure — somebody is going to keep using it. The SPLC's campaign worked, which means the next advocacy group, the next administration, the next coalition is already studying the playbook. That's the lesson successful coercion teaches.
+
+3. **The mechanics of this case are boring, and that's the point.** McKenzie is right — fictitious entity, false bank application, money movement, written admission. There is no exotic legal theory here. The reason this is shocking is that we somehow accepted, as a society, that the rules everyone else has to follow didn't apply to organizations whose mission statement was altruistic. They did. They do. They will.
+
+## Worth saying out loud
+
+I've watched a lot of friends in tech bite their tongue on this stuff for a decade. I've done it myself. The cost of speaking up was high and the cost of silence felt like zero, so we shrugged and shipped product and figured the grown-ups had it handled.
+
+The grown-ups did not have it handled. The grown-ups were running CIA-named shell companies and lobbying our payment networks to enforce their political preferences while we stayed quiet because it was awkward to ask questions.
+
+You don't have to become a culture warrior. You don't have to pick a team. You do have to be willing to look at evidence — a federal indictment, a written confession, a documented multi-year lobbying campaign against the financial system you depend on — and say, out loud, *this is not cool, regardless of who did it.*
+
+If we can't manage that much, the answer to "how do we trust our institutions ever again?" is simple. We don't. And we shouldn't.


### PR DESCRIPTION
## Summary

Opinion post on the April 21, 2026 SPLC bank fraud indictment, building on Patrick McKenzie's [writeup at *Bits About Money*](https://www.bitsaboutmoney.com/archive/nonprofit-indicted-bank-fraud/). Uses the case as a prompt to examine concentrated soft power over financial rails — a recurring USIPS theme that overlaps with prior posts on Fair Access to Banking and the OCC reputational risk rule.

The piece is intentionally voicier and more first-person than typical USIPS posts; happy to dial it back if that's the wrong register for the site.

## Files

- `content/blog/2026/05/splc-indictment-and-trust.md` — the post (KC-authored)
- `content/blog/2026/05/_index.md` — new May 2026 month section

## Notes

- No `blog_image` set. If we want OG/social cards, drop a `.webp` at `image/blog/2026/05/splc-indictment-and-trust.webp` and add the front-matter line.
- `zola check --skip-external-links` passes clean (only pre-existing orphan warnings).
- McKenzie is linked at the top of the post and in the §1014 reference; the indictment statute is also linked to Cornell LII.

## Test plan

- [ ] `npm install && npm run build:ts && zola serve --drafts` and read the post in-browser
- [ ] Confirm KC author card renders correctly (image + bio from `config.toml [extra.authors]`)
- [ ] Decide whether to add a hero image before merging
- [ ] Sanity-check tone for USIPS voice