### PR TITLE
Remove dead link in page

### DIFF
--- a/content/products/tartarus.md
+++ b/content/products/tartarus.md
@@ -43,6 +43,4 @@ Unlike commercial DDoS protection services:
 
 ## Get involved
 
-Tartarus is under active development. If you're a developer interested in helping protect the Lower Internet, check out the source code on [GitHub](https://github.com/usips/tartarus-rs). If you would like to financially support our development, please sponsor us on [GitHub Sponsors](https://github.com/sponsors/usips)!
-
 If you run an independent website and need help, [reach out to Joshua Moon](/us/board).


### PR DESCRIPTION
Tartarus-rs does not exist on the USIPS github page, unless this changes soon, it would be more professional to keep this off the website, as the tartarus checks directly link to the page.